### PR TITLE
ccache disabled if CCACHE_EXEC not specified

### DIFF
--- a/tasks/bashrc.yml
+++ b/tasks/bashrc.yml
@@ -13,3 +13,4 @@
     - "export OUT_DIR_COMMON_BASE=/home/ubuntu/build"
     - "export USE_CCACHE=1"
     - "export CCACHE_DIR={{ build_dir }}/.ccache"
+    - "export CCACHE_EXEC=/usr/bin/ccache"


### PR DESCRIPTION
I was surprised to not have ccache work for the Android build (fast for the kernel build) until I read the following:

https://sx.ix5.org/info/post/android-q-changes/

```
ccache is no longer supported by default, the prebuilt ccache exec has been removed.
```

although maybe ccache is not recommended, I'm keeping it here by fixing the CCACHE_EXEC environment variable.